### PR TITLE
fixes: provider configuration for version

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,6 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 3.11"
+    }
+  }
+}
+
 provider "aws" {
   region = var.region
-  version = "~> 3.11"
 }
 
 module "network" {


### PR DESCRIPTION
Fixes the AWS provider example. From Terraform version 0.13 and later there is a change in defining provider version and source to use. This PR takes care of that change.
for more information  on the change - https://www.terraform.io/docs/language/providers/requirements.html