### PR TITLE
bugfix/accurics_remediation_7250636972131561 - Auto Generated Pull Request From Accurics

### DIFF
--- a/terraform/aws/modules/compute/main.tf
+++ b/terraform/aws/modules/compute/main.tf
@@ -27,7 +27,7 @@ resource "aws_iam_role" "km_ecs_task_execution_role" {
 EOF
 
   tags = merge(var.default_tags, {
-    name        = "km_ecs_task_execution_role_${var.environment}"
+    name = "km_ecs_task_execution_role_${var.environment}"
   })
 }
 
@@ -106,7 +106,7 @@ resource "aws_ecs_service" "km_ecs_service" {
   network_configuration {
     assign_public_ip = true
     subnets          = var.private_subnet
-    security_groups  = [ var.elb_sg ]
+    security_groups  = [var.elb_sg]
   }
   tags = merge(var.default_tags, {
   })
@@ -114,18 +114,18 @@ resource "aws_ecs_service" "km_ecs_service" {
 
 resource "aws_cloudwatch_log_group" "km_log_group" {
   name              = "km_log_group_${var.environment}"
-  retention_in_days = 1
+  retention_in_days = 120
 
   tags = merge(var.default_tags, {
     Name = "km_log_group_${var.environment}"
   })
 }
 
-resource "aws_instance" "km_vm"{
-  ami = data.aws_ami.ubuntu_ami.id
-  instance_type = "t2.micro"
-  vpc_security_group_ids = [ var.elb_sg ]
-  subnet_id = var.public_subnet[0]
+resource "aws_instance" "km_vm" {
+  ami                    = data.aws_ami.ubuntu_ami.id
+  instance_type          = "t2.micro"
+  vpc_security_group_ids = [var.elb_sg]
+  subnet_id              = var.public_subnet[0]
   tags = merge(var.default_tags, {
     Name = "km_vm_${var.environment}"
   })


### PR DESCRIPTION
AWS CloudWatch Log Group can be set with a log retention policy using AWS Console.
 In AWS Console - 
 1. Sign in to AWS Console and go to the CloudWatch console.
 2. Select Log Groups in the navigation pane.
 3. Select the log group to update.
 4. Select 'Edit retemtion' and change the log retention value to 90 days.