### PR TITLE
Adding sample yaml for newly supported CFT resources

### DIFF
--- a/cft/ec2/natgateway/deploy.yaml
+++ b/cft/ec2/natgateway/deploy.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myNatgw:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: "eip-5869568596"
+      ConnectivityType: "public"
+      SubnetId: test-subnet-sp

--- a/cft/ec2/output.json
+++ b/cft/ec2/output.json
@@ -315,5 +315,111 @@
             "max_severity": "",
             "min_severity": ""
         }
-    ]
+    ],
+    "aws_nat_gateway": [
+        {
+          "id": "aws_nat_gateway.myNatgw",
+          "name": "myNatgw",
+          "source": "deploy.yaml",
+          "line": 1,
+          "type": "aws_nat_gateway",
+          "config": {
+            "tags": null,
+            "name": "",
+            "allocation_id": "eip-5869568596",
+            "connectivity_type": "public",
+            "subnet_id": "test-subnet-sp"
+          },
+          "skip_rules": [],
+          "max_severity": "",
+          "min_severity": ""
+        }
+      ],
+      "aws_route_table": [
+        {
+          "id": "aws_route_table.test-route-table",
+          "name": "test-route-table",
+          "source": "deploy.yaml",
+          "line": 1,
+          "type": "aws_route_table",
+          "config": {
+            "tags": null,
+            "name": "",
+            "vpc_id": "test-vpc-sp"
+          },
+          "skip_rules": [],
+          "max_severity": "",
+          "min_severity": ""
+        }
+      ],
+      "aws_route_table_association": [
+        {
+          "id": "aws_route_table_association.myinstance",
+          "name": "myinstance",
+          "source": "deploy.yaml",
+          "line": 1,
+          "type": "aws_route_table_association",
+          "config": {
+            "tags": null,
+            "name": "",
+            "route_table_id": "test-route-table",
+            "subnet_id": "test-subnet-sp"
+          },
+          "skip_rules": [],
+          "max_severity": "",
+          "min_severity": ""
+        }
+      ],
+      "aws_route": [
+        {
+          "id": "aws_route.test-route-sp",
+          "name": "test-route-sp",
+          "source": "deploy.yaml",
+          "line": 1,
+          "type": "aws_route",
+          "config": {
+            "tags": null,
+            "name": "",
+            "carrier_gateway_id": "",
+            "destination_cidr_block": "0.0.0.0/0",
+            "destination_ipv6_cidr_block": "",
+            "egress_only_gateway_id": "",
+            "gateway_id": "",
+            "instance_id": "",
+            "local_gateway_id": "",
+            "nat_gateway_id": "myNatgw",
+            "network_interface_id": "String",
+            "route_table_id": "test-route-sp",
+            "transit_gateway_id": "",
+            "vpc_endpoint_id": "",
+            "vpc_peering_connection_id": ""
+          },
+          "skip_rules": [],
+          "max_severity": "",
+          "min_severity": ""
+        }
+      ],
+      "aws_subnet": [
+        {
+          "id": "aws_subnet.test-subnet-sp",
+          "name": "test-subnet-sp",
+          "source": "deploy.yaml",
+          "line": 1,
+          "type": "aws_subnet",
+          "config": {
+            "tags": null,
+            "name": "",
+            "assign_ipv6_address_on_creation": false,
+            "availability_zone": "us-east-1a",
+            "cidr_block": "10.0.2.0/24",
+            "ipv6_cidr_block": "",
+            "map_public_ip_on_launch": false,
+            "outpost_arn": "",
+            "vpc_id": "test-vpc-sp"
+          },
+          "skip_rules": [],
+          "max_severity": "",
+          "min_severity": ""
+        }
+      ]
 }

--- a/cft/ec2/route-table-association/deploy.yaml
+++ b/cft/ec2/route-table-association/deploy.yaml
@@ -1,0 +1,7 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  myinstance:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties: 
+      RouteTableId: test-route-table
+      SubnetId: test-subnet-sp

--- a/cft/ec2/route-table/deploy.yaml
+++ b/cft/ec2/route-table/deploy.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  test-route-table: 
+    Type: AWS::EC2::RouteTable
+    Properties: 
+      VpcId: test-vpc-sp

--- a/cft/ec2/route/deploy.yaml
+++ b/cft/ec2/route/deploy.yaml
@@ -1,0 +1,9 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  test-route-sp:
+    Type: AWS::EC2::Route
+    Properties:
+      DestinationCidrBlock: "0.0.0.0/0"
+      NatGatewayId: myNatgw
+      NetworkInterfaceId: String
+      RouteTableId: test-route-sp

--- a/cft/ec2/subnet/deploy.yaml
+++ b/cft/ec2/subnet/deploy.yaml
@@ -1,0 +1,8 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Resources:
+  test-subnet-sp:
+    Type: AWS::EC2::Subnet
+    Properties: 
+      VpcId: test-vpc-sp
+      AvailabilityZone: "us-east-1a"
+      CidrBlock: 10.0.2.0/24


### PR DESCRIPTION
Adding test CFT Yamls for following resources:
- AWS NAT Gateway
- AWS Route
- AWS Route Table
- AWS Route Table Association
- AWS Subnet

Also updated the cft/ec2/output.json with the output generated by terrascan