### PR TITLE
nic device index is string now

### DIFF
--- a/cft/ec2/instance/deploy.yml
+++ b/cft/ec2/instance/deploy.yml
@@ -11,11 +11,11 @@ Resources:
       Monitoring: false
       NetworkInterfaces:
         - NetworkInterfaceId: nic1
-          DeviceIndex: 1
+          DeviceIndex: "1"
           DeleteOnTermination: false
           AssociatePublicIpAddress: false
         - NetworkInterfaceId: nic2
-          DeviceIndex: 2
+          DeviceIndex: "2"
           DeleteOnTermination: true
           AssociatePublicIpAddress: true
       Tags:


### PR DESCRIPTION
nic device index is string now in AWS::EC2::Instance