### PR TITLE
change deprecated resource

### DIFF
--- a/terraform/aws/modules/storage/main.tf
+++ b/terraform/aws/modules/storage/main.tf
@@ -46,7 +46,7 @@ resource "aws_db_instance" "km_db" {
   name                      = "km_db_${var.environment}"
   allocated_storage         = 20
   engine                    = "postgres"
-  engine_version            = "10.6"
+  engine_version            = "11.22"
   instance_class            = "db.t3.medium"
   storage_type              = "gp2"
   password                  = var.db_password
@@ -121,7 +121,7 @@ resource "aws_s3_bucket_ownership_controls" "km_blob_storage" {
 resource "aws_s3_bucket_acl" "km_blob_storage" {
   depends_on = [aws_s3_bucket_ownership_controls.km_blob_storage]
 
-  bucket = "km-blob-storage${var.environment}"
+  bucket = aws_s3_bucket.km_blob_storage.id
   acl    = "private"
 }
 

--- a/terraform/aws/modules/storage/main.tf
+++ b/terraform/aws/modules/storage/main.tf
@@ -103,10 +103,26 @@ resource "aws_ssm_parameter" "km_ssm_db_name" {
 
 resource "aws_s3_bucket" "km_blob_storage" {
   bucket = "km-blob-storage-${var.environment}"
-  acl    = "private"
+  # acl    = "private"
   tags = merge(var.default_tags, {
     name = "km_blob_storage_${var.environment}"
   })
+}
+
+resource "aws_s3_bucket_ownership_controls" "km_blob_storage" {
+  depends_on = [aws_s3_bucket.km_blob_storage]
+  
+  bucket = aws_s3_bucket.km_blob_storage.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "km_blob_storage" {
+  depends_on = [aws_s3_bucket_ownership_controls.km_blob_storage]
+
+  bucket = "km-blob-storage${var.environment}"
+  acl    = "private"
 }
 
 resource "aws_s3_bucket" "km_public_blob" {


### PR DESCRIPTION
The code includes the deprecated resource. I changed the resource by removing the config ACL on the s3 resource and adding a new configuration to setup ACL on s3.

<img width="542" alt="s3-acl-depcrecated" src="https://github.com/user-attachments/assets/2c72c871-d4e7-4e39-84aa-57cbff9490d2">

Source: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl
Related issue: #55